### PR TITLE
Enable ES6 for JavaScript and add tests to check validity for `assets:precompile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.2.0'
 gem 'mysql2', '~> 0.4.0'
 gem 'jquery-rails'
 gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '>= 4.1.0'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'slim-rails'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+# Overview
+
+- `precompile.Dockerfile`: rake assets:precompile の検証用Dockerイメージ
+- `test-compose.yml`: 各種テストを行うためのdocker-composeファイル
+
+# Usage
+
+```sh
+# プロジェクトルートにて以下を実行
+% docker-compose -f ./docker/test-compose.yml run assets_precompile
+# servicesとして登録されているすべてのテストを実行する場合
+% docker-compose -f ./docker/test-compose.yml up
+# ただし、upを使う場合はexit codeが0となるので、CIなどでは使えない.
+```

--- a/docker/precompile.Dockerfile
+++ b/docker/precompile.Dockerfile
@@ -1,0 +1,16 @@
+# This Dockerfile is made just for testing assets:precompile.
+# This image is NOT supposed to work as standalone ponpe-server.
+FROM ruby:2.3.0
+
+ADD . /ponpe
+WORKDIR /ponpe
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq
+RUN apt-get install -y \
+  mysql-server
+
+RUN bundle install
+RUN cp config/database.yml.sample config/database.yml
+
+CMD ["bundle", "exec", "rake", "assets:precompile"]

--- a/docker/test-compose.yml
+++ b/docker/test-compose.yml
@@ -1,0 +1,13 @@
+# docker-compose just for testing
+version: '3'
+services:
+    # Test assets:precompile
+    assets_precompile:
+        environment:
+            - RAILS_ENV=production
+        build:
+            context: ../
+            dockerfile: ./docker/precompile.Dockerfile
+        volumes:
+            - ../app/assets:/ponpe/app/assets
+        

--- a/test
+++ b/test
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit
+set -o verbose
+
+docker-compose -f ./docker/test-compose.yml run assets_precompile


### PR DESCRIPTION
- Docker, docker-composeを使って独立した`assets:precompile`用のテスト環境をつくった
- 一応、そのランナーとして `test` っていうスクリプトを追加
- `uglifier`のバージョンアップをした（上記のテストは通ってる（precompileはできてる））

![image](https://user-images.githubusercontent.com/931554/48606670-61974c00-e9c3-11e8-8353-3c1de3bd15cb.png)
